### PR TITLE
Add status mapping for "Gestopt"

### DIFF
--- a/lblod/transform_data.py
+++ b/lblod/transform_data.py
@@ -153,6 +153,10 @@ def transform_data(data):
                 status = {
                     "@id": "http://lblod.data.gift/concepts/abf4fee82019f88cf122f986830621ab"
                 }
+            elif formatted_status == "gestopt":
+                status = {
+                    "@id": "http://lblod.data.gift/concepts/3d790fd9-bec9-43dd-840c-f835eda6997e"
+                }
 
         if not primary_location:
             for locatie in locaties:


### PR DESCRIPTION
**[CLBV-1059]**

There was no mapping for the status "Gestopt" in the data transformer, but that status occasionally pops up in the data from Verenigingsregister.

This PR adds a mapping for that status. See the PR on the Verenigingen Loket for more about the status.